### PR TITLE
[OPS-665] Unpin cabal hashes

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -2,6 +2,7 @@ final: previous:
 
 let
   inherit (final) callPackage runCommand lib;
+  inherit (final.stdenv) mkDerivation;
 
   gitignore = import (fetchGit {
     url = https://github.com/siers/nix-gitignore;
@@ -11,6 +12,19 @@ let
 in
 
 {
+  all-cabal-hashes = mkDerivation {
+    name = "all-cabal-hashes.tar.gz";
+
+    src = builtins.fetchurl {
+      url = https://github.com/commercialhaskell/all-cabal-hashes/archive/hackage.tar.gz;
+    };
+
+    phases = [ "buildPhase" ];
+    buildPhase = ''
+      cp -r $src $out
+    '';
+  };
+
   buildFlatpak = callPackage (fetchGit {
     url = https://github.com/serokell/nix-flatpak;
     rev = "76dc0f06d21f6063cb7b7d2291b8623da24affa9";


### PR DESCRIPTION
Given that:

* all-cabal-hashes gets asked to be bumped every other day
* all-cabal-hashes does not delete old hashes, only adds new ones

We should probably just unpin it in  serokell-closure.

This should be completely safe, and individual projects can still override it with a pin if necessary.

I've built Ariadne and Disciplina locally, just to be sure it doesn't immediately break anything.