### PR TITLE
[OPS-665] use fetchurl for cabal-hashes

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -8,6 +8,8 @@ let
     ref = "v1.0.2";
     rev = "7a2a637fa4a753a9ca11f60eab52b35241ee3c2f";
   }) { inherit (final) lib; };
+  all-cabal-hashes-component = name: version: type:
+    builtins.fetchurl "https://raw.githubusercontent.com/commercialhaskell/all-cabal-hashes/hackage/${name}/${version}/${name}.${type}";
 in
 
 {
@@ -68,4 +70,12 @@ in
     url = https://github.com/serokell/stack4nix;
     rev = "e227092e52726cfd41cba9930c02691eb6e61864";
   }) { pkgs = final; };
+
+  haskellPackages = previous.haskellPackages.override { overrides = final: previous: {
+    hackage2nix = name: version: final.haskellSrc2nix {
+      name   = "${name}-${version}";
+      sha256 = ''$(sed -e 's/.*"SHA256":"//' -e 's/".*$//' "${all-cabal-hashes-component name version "json"}")'';
+      src    = all-cabal-hashes-component name version "cabal";
+    };
+  };};
 }


### PR DESCRIPTION
Fetching the all-cabal-hashes tar (#8) has some problems.
- It refetches and re-call-cabal's every dependency every 30 minutes (we could fix this using builtins.path hacks maybe)
- It's inefficient because it does unindexed access to the tarball very often, which is slow (we could fix this by using a zip)

It turns out fetchurl is pretty fast when fetching single files from github. This is faster than the old approach, even with `--tarball-ttl 0`. Whether this repo is the right place for it is debatable.