### PR TITLE
qemu: disable docs because of makeinfo bug

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -68,4 +68,9 @@ in
     url = https://github.com/serokell/stack4nix;
     rev = "e227092e52726cfd41cba9930c02691eb6e61864";
   }) { pkgs = final; };
+
+  # Work around: makeinfo hangs forever when building qemu
+  qemu = previous.qemu.overrideAttrs ( oldAttrs: rec {
+    configureFlags = oldAttrs.configureFlags ++ [ "--disable-docs" ];
+  });
 }


### PR DESCRIPTION
I know the correct thing would be to fix this. But I spent 4 hours on it, and eventually decided to just disable docs because we don't need them at all.

Proper fix should be sent upstream, if applicable.