### PR TITLE
mixToNix: bump to 79c819013f2e645f64b33f93d4a53c0bc902d596

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -62,8 +62,8 @@ in
   };
 
   mixToNix = callPackage (fetchGit {
-    url = https://github.com/serokell/mix-to-nix;
-    rev = "a7e109574a84fc0bcf811a5cac7eefb6317d2efa";
+    url = https://gitlab.com/transumption/mix-to-nix;
+    rev = "d66c85b45eb9d0c662fe5b32cbcf3fb6529423ca";
   }) {};
 
   nginxStable = previous.nginxStable.overrideAttrs (super: {


### PR DESCRIPTION
Short list of changes:

- Mix to Nix has been rewritten in Nix. The only Elixir part remaining is one that evaluates Elixir term in `mix.lock` and spits out JSON.

- If `src` is a path (for example, `mixToNix { src = ./.; }`), Mix to Nix will clean it with `lib.cleanSource`, and additionally remove `_build/` and `deps/`.

- `gzseek` has been replaced with [`binwalk`](https://github.com/ReFirmLabs/binwalk).

- `.ez` Hex fetch has been replaced with Nixpkgs Hex. This improves compatibility with Distillery and reduces build time.

- `checkPhase` has been added, enabled by default. It runs `mix test`. If you don't want tests, append `.overrideAttrs (super: { doCheck = false; })` to `mixToNix` call.

- Derivation now sets `LOCALE_ARCHIVE` and `LANG`. This will suppress warnings about incorrect locale and potential degradations.

- Rebar3 plugins like `pc`, `rebar3_hex` are now supported. This drastically improves compatibility with NIF-containing packages. See `tests/02-fast-yaml` directory for an example.

- Extensive docs, CI, some tests. Check out at https://gitlab.com/transumption/mix-to-nix#overview.

**Important**: API has changed.

Before:

```nix
with import <nixpkgs> {};

let
  mixToNix = callPackage (fetchTarball "...") {};
in

callPackage (mixToNix (lib.cleanSource ./.)) {}
```

After:

```nix
with import <nixpkgs> {};

let
  mixToNix = callPackage (fetchTarball "...") {};
in

mixToNix { src = ./.; }
```

Please report any degradations and rough edges.